### PR TITLE
content/python/django: remove redundant "URL quoted"

### DIFF
--- a/content/python/django/_index.md
+++ b/content/python/django/_index.md
@@ -68,7 +68,7 @@ In the database server logs, the comment's fields are:
 
 * comma separated key-value pairs e.g. `controller='index'`
 * values are SQL escaped i.e. `key='value'`
-* URL-quoted except for the equals(`=`) sign e.g `route='%5Epolls/%24'`. so should be URL-unquoted
+* URL-quoted except for the equals(`=`) sign e.g `route='%5Epolls/%24'`. so should be URL-unquoted when being consumed
 
 #### Sample log entry
 
@@ -87,9 +87,9 @@ framework='django%3A2.2.1',route='%5Epolls/%24' */
 Field|Format|Description|Example
 ---|---|---|---
 `controller`|`<string>`|The name of the view from `django.conf.urls.url` as described in your urls.py file e.g. as per `url(r'^$', views.index, name='index')`|controller='index'
-`db_driver`|`<database_driver>:<version>`|URL quoted name and version of the database driver|`db_driver='django.db.backends.postgresql'`
-`framework`|`'django%3A<django_version>'`|the URL quoted combination of the word "django" as the key and the version of Django being used|framework='django%3A2.2.1'
-`route`|`<the route used>`|The URL-quoted route used for the controller|`route='%5Epolls/%24'`
+`db_driver`|`<database_driver>:<version>`|Name and version of the database driver|`db_driver='django.db.backends.postgresql'`
+`framework`|`'django%3A<django_version>'`|combination of the word "django" as the key and the version of Django being used|framework='django%3A2.2.1'
+`route`|`<the route used>`|route used for the controller|`route='%5Epolls/%24'`
 
 #### References
 


### PR DESCRIPTION
"URL quoted" is used to describe the general nature
of both keys and values right before we make the table
of fields, thus it was redundant to use it in every
description.

Fixes #11