### PR TITLE
content/python: remove import *

### DIFF
--- a/content/python/psycopg2/_index.md
+++ b/content/python/psycopg2/_index.md
@@ -59,12 +59,7 @@ cd python-sql-commenter/sqlcommenter-psycopg2 && python3 setup.py install
 {{</highlight>}}
 
 #### Usage
-Then in your source code
-
-```python
-from sqlcommenter.psycopg2.extension import * # or continue reading below for specific options
-```
-
+We'll perform the following imports in our source code:
 
 ### CommenterCursor
 

--- a/content/python/sqlalchemy/_index.md
+++ b/content/python/sqlalchemy/_index.md
@@ -46,11 +46,7 @@ cd python-sql-commenter/django && python3 setup.py install
 {{</highlight>}}
 {{</tabs>}}
 
-and then in your source code
-
-```python
-from sqlcommenter.sqlalchemy.executor import * # or continue reading below for specific options
-```
+and then we shall perform the following imports in our source code:
 
 
 ### before\_execute


### PR DESCRIPTION
`from {package} import *` gave the impression that there
would be side effects but also we don't want to pollute
users namespaces by encouraging to import everything
as per the old guides.

Fixes #9