### PR TITLE
content/python/django: add notes about middleware ordering

### DIFF
--- a/content/python/django/_index.md
+++ b/content/python/django/_index.md
@@ -52,14 +52,19 @@ cd python-sql-commenter/django && python3 setup.py install
 
 Please edit your `settings.py` file to include `sqlcommenter.django.middleware.SqlCommenter` in your `MIDDLEWARE` section like this:
 ```diff
---- before.txt
-+++ after.txt
+--- settings.py
++++ settings.py
 @@ -1,3 +1,4 @@
  MIDDLEWARE = [
 +  'sqlcommenter.django.middleware.SqlCommenter',
    ...
  ]
 ```
+
+{{% notice tip %}}
+If any middleware execute database queries (that you'd like commented by SqlCommenter), those middleware MUST appear after
+'sqlcommenter.django.middleware.SqlCommenter'
+{{%/ notice %}}
 
 
 ### Fields

--- a/content/python/django/aws.md
+++ b/content/python/django/aws.md
@@ -38,6 +38,11 @@ MIDDLEWARE = [
 ]
 ```
 
+{{% notice tip %}}
+If any middleware execute database queries (that you'd like commented by SqlCommenter), those middleware MUST appear after
+'sqlcommenter.django.middleware.SqlCommenter'
+{{%/ notice %}}
+
 ### References
 
 Resource|URL

--- a/content/python/django/gcp.md
+++ b/content/python/django/gcp.md
@@ -40,6 +40,11 @@ MIDDLEWARE = [
 ]
 ```
 
+{{% notice tip %}}
+If any middleware execute database queries (that you'd like commented by SqlCommenter), those middleware MUST appear after
+'sqlcommenter.django.middleware.SqlCommenter'
+{{%/ notice %}}
+
 ### References
 
 Resource|URL

--- a/content/python/django/local.md
+++ b/content/python/django/local.md
@@ -41,6 +41,12 @@ MIDDLEWARE = [
 ]
 ```
 
+{{% notice tip %}}
+If any middleware execute database queries (that you'd like commented by SqlCommenter), those middleware MUST appear after
+'sqlcommenter.django.middleware.SqlCommenter'
+{{%/ notice %}}
+
+
 ### References
 
 Resource|URL


### PR DESCRIPTION
Add notes to the relevant Django sections that if you'd like
to add middleware that make SQL queries, yet would like those
queries to be commented by SqlCommenter, then those middleware
MUST appear after `sqlcommenter.django.middleware.SqlCommenter`
in the settings.py==>MIDDLEWARE slice.

Fixes #6