### PR TITLE
all: remove space between comment stopper /* */ -> /**/

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -35,18 +35,18 @@ This log was extracted from a live web application
 2019-05-28 11:54:50.780 PDT [64128] LOG:  statement: INSERT INTO "polls_question"
 ("question_text", "pub_date") VALUES
 ('What is this?', '2019-05-28T18:54:50.767481+00:00'::timestamptz) RETURNING
-"polls_question"."id" /* controller='index',db_driver='django.db.backends.postgresql',
+"polls_question"."id" /*controller='index',db_driver='django.db.backends.postgresql',
 framework='django%3A2.2.1',route='%5Epolls/%24',
-span_id='cfb60c868a47adf9',trace_id='23d4bad1efad0bff3ebdc7b717d739e7' */
+span_id='cfb60c868a47adf9',trace_id='23d4bad1efad0bff3ebdc7b717d739e7'*/
 ```
 
 ### Interpretation
 
-On examining the SQL statement from above in [Sample](#sample) and examining the comment in `/* ... */`
+On examining the SQL statement from above in [Sample](#sample) and examining the comment in `/*...*/`
 ```sql
-/* controller='index',db_driver='django.db.backends.postgresql',
+/*controller='index',db_driver='django.db.backends.postgresql',
 framework='django%3A2.2.1',route='%5Epolls/%24',
-span_id='cfb60c868a47adf9',trace_id='23d4bad1efad0bff3ebdc7b717d739e7' */
+span_id='cfb60c868a47adf9',trace_id='23d4bad1efad0bff3ebdc7b717d739e7'*/
 ```
 
 we can now correlate and pinpoint the fields in the above slow SQL query to our source code in our web application:

--- a/content/databases/postgresql.md
+++ b/content/databases/postgresql.md
@@ -40,8 +40,8 @@ produces such output
 2019-05-31 16:27:31.190 PDT [19183] LOG:  statement: SET TIME ZONE 'UTC'
 2019-05-31 16:27:31.195 PDT [19183] LOG:  statement: INSERT INTO "polls_question"
 ("question_text", "pub_date") VALUES ('Wassup?', '2019-05-31T23:27:31.175952+00:00'::timestamptz)
-RETURNING "polls_question"."id" /* controller='index',db_driver='django.db.backends.postgresql',
-framework='django%3A2.2.1',route='%5Epolls/%24' */
+RETURNING "polls_question"."id" /*controller='index',db_driver='django.db.backends.postgresql',
+framework='django%3A2.2.1',route='%5Epolls/%24'*/
 ```
 
 ### References

--- a/content/introduction/_index.md
+++ b/content/introduction/_index.md
@@ -33,18 +33,18 @@ This log was extracted from a live web application
 2019-05-28 11:54:50.780 PDT [64128] LOG:  statement: INSERT INTO "polls_question"
 ("question_text", "pub_date") VALUES
 ('What is this?', '2019-05-28T18:54:50.767481+00:00'::timestamptz) RETURNING
-"polls_question"."id" /* controller='index',db_driver='django.db.backends.postgresql',
+"polls_question"."id" /*controller='index',db_driver='django.db.backends.postgresql',
 framework='django%3A2.2.1',route='%5Epolls/%24',
-span_id='cfb60c868a47adf9',trace_id='23d4bad1efad0bff3ebdc7b717d739e7' */
+span_id='cfb60c868a47adf9',trace_id='23d4bad1efad0bff3ebdc7b717d739e7'*/
 ```
 
 ### Interpretation
 
-On examining the SQL statement from above in [Sample](#sample) and examining the comment in `/* ... */`
+On examining the SQL statement from above in [Sample](#sample) and examining the comment in `/*...*/`
 ```sql
-/* controller='index',db_driver='django.db.backends.postgresql',
+/*controller='index',db_driver='django.db.backends.postgresql',
 framework='django%3A2.2.1',route='%5Epolls/%24',
-span_id='cfb60c868a47adf9',trace_id='23d4bad1efad0bff3ebdc7b717d739e7' */
+span_id='cfb60c868a47adf9',trace_id='23d4bad1efad0bff3ebdc7b717d739e7'*/
 ```
 
 we can now correlate and pinpoint the fields in the above slow SQL query to our source code in our web application:

--- a/content/java/hibernate/_index.md
+++ b/content/java/hibernate/_index.md
@@ -69,7 +69,7 @@ After following the example below you should be able to see in your PostgreSQL l
 2019-06-12 15:43:23.260 PDT [34305] LOG:  execute <unnamed>:
 select question0_.id as id1_0_, question0_.question_text as question2_0_,
 question0_.pub_date as pub_date3_0_ from polls_question question0_
-/* span_id='bcd07633524964ba',trace_id='e6588efe3fe58814f2afc0c63a2d9c55' */
+/*span_id='bcd07633524964ba',trace_id='e6588efe3fe58814f2afc0c63a2d9c55'*/
 ```
 
 {{% notice tip %}}

--- a/content/node/knex/_index.md
+++ b/content/node/knex/_index.md
@@ -150,7 +150,7 @@ Application listening on 3000
 On making a request to that server at `http://localhost:3000/polls/1000`, the PostgreSQL logs show:
 ```shell
 2019-06-03 14:32:10.842 PDT [32004] LOG:  statement: SELECT * from polls_question
-/* db_driver='knex%3A0.16.5',db_version='11.3',route='%5E%2Fpolls%2F%3Aparam' */
+/*db_driver='knex%3A0.16.5',db_version='11.3',route='%5E%2Fpolls%2F%3Aparam'*/
 ```
 
 

--- a/content/node/sequelize/_index.md
+++ b/content/node/sequelize/_index.md
@@ -145,7 +145,7 @@ Application listening on 3000
 On making a request to that server at `http://localhost:3000/polls/1000`, the PostgreSQL logs show:
 ```shell
 2019-06-03 15:09:35.575 PDT [32665] LOG:  statement: SELECT * from polls_question
-/* client_timezone='%2B00%3A00',db_driver='sequelize',db_version='11.3.0',route='%5E%2Fpolls%2F%3Aparam' */
+/*client_timezone='%2B00%3A00',db_driver='sequelize',db_version='11.3.0',route='%5E%2Fpolls%2F%3Aparam'*/
 ```
 
 

--- a/content/python/django/_index.md
+++ b/content/python/django/_index.md
@@ -83,8 +83,8 @@ After making a request into the middleware-enabled polls web-app.
 2019-05-28 11:54:50.780 PDT [64128] LOG:  statement: INSERT INTO "polls_question"
 ("question_text", "pub_date") VALUES
 ('Wassup?', '2019-05-28T18:54:50.767481+00:00'::timestamptz) RETURNING "polls_question"."id"
-/* controller='index',db_driver='django.db.backends.postgresql',
-framework='django%3A2.2.1',route='%5Epolls/%24' */
+/*controller='index',db_driver='django.db.backends.postgresql',
+framework='django%3A2.2.1',route='%5Epolls/%24'*/
 ```
 
 #### Expected fields

--- a/content/python/flask/_index.md
+++ b/content/python/flask/_index.md
@@ -88,9 +88,9 @@ which when run by `python3 main.py` and on visiting http://localhost:8088/polls 
 
 ```shell
 2019-06-08 12:19:11.284 PDT [70984] LOG:  statement: SELECT * FROM polls_question
-/* controller='get_polls',db_driver='psycopg2',framework='sqlalchemy%3A1.3.4',
+/*controller='get_polls',db_driver='psycopg2',framework='sqlalchemy%3A1.3.4',
 route='/polls',span_id='9bbd4868cf0ba2c3',
-trace_id='5b3df77064f35f091e89fb40022e2a1d',web_framework='flask%3A1.0.3' */
+trace_id='5b3df77064f35f091e89fb40022e2a1d',web_framework='flask%3A1.0.3'*/
 ```
 
 #### With sqlalchemy
@@ -133,9 +133,9 @@ which when run by `python3 main.py` and on visiting http://localhost:8089/polls 
 
 ```shell
 2019-06-08 12:17:59.518 PDT [73546] LOG:  statement: SELECT * FROM polls_question
-/* controller='get_polls',db_driver='psycopg2%%3A2.8.2%%20%%28dt%%20dec%%20pq3%%20ext%%20lo64%%29',
+/*controller='get_polls',db_driver='psycopg2%%3A2.8.2%%20%%28dt%%20dec%%20pq3%%20ext%%20lo64%%29',
 dbapi_level='2.0',dbapi_threadsafety=2,driver_paramstyle='pyformat',
-libpq_version=100001,route='/polls',web_framework='flask%%3A1.0.3' */
+libpq_version=100001,route='/polls',web_framework='flask%%3A1.0.3'*/
 ```
 
 ### References

--- a/content/python/psycopg2/_index.md
+++ b/content/python/psycopg2/_index.md
@@ -188,15 +188,15 @@ Examining our Postgresql server logs
 {{<tabs "Without OpenCensus" "With OpenCensus">}}
 {{<highlight shell>}}
 2019-06-01 19:06:49.616 PDT [25573] LOG:  statement: SELECT * FROM polls_question
-/* db_driver='psycopg2%%3A2.8.2%%20%%28dt%%20dec%%20pq3%%20ext%%20lo64%%29',
-dbapi_level='2.0',dbapi_threadsafety=2,driver_paramstyle='pyformat',libpq_version=100001 */
+/*db_driver='psycopg2%%3A2.8.2%%20%%28dt%%20dec%%20pq3%%20ext%%20lo64%%29',
+dbapi_level='2.0',dbapi_threadsafety=2,driver_paramstyle='pyformat',libpq_version=100001*/
 {{</highlight>}}
 
 {{<highlight shell>}}
 2019-06-04 10:38:39.170 PDT [35555] LOG:  statement: SELECT * FROM polls_question
-/* db_driver='psycopg2%%3A2.8.2%%20%%28dt%%20dec%%20pq3%%20ext%%20lo64%%29',
+/*db_driver='psycopg2%%3A2.8.2%%20%%28dt%%20dec%%20pq3%%20ext%%20lo64%%29',
 dbapi_level='2.0',dbapi_threadsafety=2,driver_paramstyle='pyformat',libpq_version=100001,
-span_id='a247e1cdad219d6b',trace_id='de134af00138e4aadc6b386018cace5d' */
+span_id='a247e1cdad219d6b',trace_id='de134af00138e4aadc6b386018cace5d'*/
 {{</highlight>}}
 {{</tabs>}}
 

--- a/content/python/sqlalchemy/_index.md
+++ b/content/python/sqlalchemy/_index.md
@@ -67,8 +67,8 @@ Please ensure that you set `retval=True` when listening for events
 and this will produce such output on for example a Postgresql database logs:
 ```shell
 2019-06-04 10:27:14.919 PDT [35412] LOG:  statement: SELECT * FROM polls_question
-/* db_driver='psycopg2',framework='sqlalchemy%3A1.3.4',
-span_id='07ac7d9f6ed8d66e',trace_id='e6e5a8d1a855d7e68aa9b1ab5bf1f027' */
+/*db_driver='psycopg2',framework='sqlalchemy%3A1.3.4',
+span_id='07ac7d9f6ed8d66e',trace_id='e6e5a8d1a855d7e68aa9b1ab5bf1f027'*/
 ```
 
 #### <a name="with-opencensus"></a> with_openCensus=True
@@ -169,13 +169,13 @@ Examining our Postgresql server logs
 {{<tabs "Without OpenCensus" "With OpenCensus">}}
 {{<highlight shell>}}
 2019-06-04 10:28:30.730 PDT [35416] LOG:  statement: SELECT * FROM polls_question
-/* db_driver='psycopg2',framework='sqlalchemy%3A1.3.4' */
+/*db_driver='psycopg2',framework='sqlalchemy%3A1.3.4'*/
 {{</highlight>}}
 
 {{<highlight shell>}}
 2019-06-04 10:27:14.919 PDT [35412] LOG:  statement: SELECT * FROM polls_question
-/* db_driver='psycopg2',framework='sqlalchemy%3A1.3.4',
-span_id='07ac7d9f6ed8d66e',trace_id='e6e5a8d1a855d7e68aa9b1ab5bf1f027' */
+/*db_driver='psycopg2',framework='sqlalchemy%3A1.3.4',
+span_id='07ac7d9f6ed8d66e',trace_id='e6e5a8d1a855d7e68aa9b1ab5bf1f027'*/
 {{</highlight>}}
 {{</tabs>}}
 


### PR DESCRIPTION
Removed the spaces between the first comment stopper /*
and */ thus, instead of
/* {COMMENT} */
we now have
/*{COMMENT}*/

The change for Ruby/Marginalia hasn't yet been performed
though.