### PR TITLE
introduction, python: document W3C TraceContext output

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -37,7 +37,8 @@ This log was extracted from a live web application
 ('What is this?', '2019-05-28T18:54:50.767481+00:00'::timestamptz) RETURNING
 "polls_question"."id" /*controller='index',db_driver='django.db.backends.postgresql',
 framework='django%3A2.2.1',route='%5Epolls/%24',
-span_id='cfb60c868a47adf9',trace_id='23d4bad1efad0bff3ebdc7b717d739e7'*/
+traceparent='00-5bd66ef5095369c7b0d1f8f4bd33716a-c532cb4098ac3dd2-01',
+tracestate='congo%%3Dt61rcWkgMzE%%2Crojo%%3D00f067aa0ba902b7'*/
 ```
 
 ### Interpretation
@@ -46,7 +47,8 @@ On examining the SQL statement from above in [Sample](#sample) and examining the
 ```sql
 /*controller='index',db_driver='django.db.backends.postgresql',
 framework='django%3A2.2.1',route='%5Epolls/%24',
-span_id='cfb60c868a47adf9',trace_id='23d4bad1efad0bff3ebdc7b717d739e7'*/
+traceparent='00-5bd66ef5095369c7b0d1f8f4bd33716a-c532cb4098ac3dd2-01',
+tracestate='congo%%3Dt61rcWkgMzE%%2Crojo%%3D00f067aa0ba902b7'*/
 ```
 
 we can now correlate and pinpoint the fields in the above slow SQL query to our source code in our web application:
@@ -57,8 +59,8 @@ Original field|Interpretation
 `db_driver='django.db.backends.postgresql'`|Database driver `django.db.backends.postgresql`
 `framework='django%3A2.2.1'`|Framework version of `django 2.2.1`
 `route='%5Epolls/%24'`|Route of `^/polls/$` 
-`span_id='cfb60c868a47adf9'`|[OpenCensus SpanID](https://opencensus.io/tracing/span/spanid/) of `cfb60c868a47adf9`
-`trace_id='23d4bad1efad0bff3ebdc7b717d739e7'`|[OpenCensus TraceID](https://opencensus.io/tracing/span/traceid/) of `23d4bad1efad0bff3ebdc7b717d739e7`
+`traceparent='00-5bd66ef5095369c7b0d1f8f4bd33716a-c532cb4098ac3dd2-01'`|[W3C TraceContext.Traceparent](https://www.w3.org/TR/trace-context/#traceparent-field) of '00-5bd66ef5095369c7b0d1f8f4bd33716a-c532cb4098ac3dd2-01'
+`tracestate='congo%%3Dt61rcWkgMzE%%2Crojo%%3D00f067aa0ba902b7'`|[W3C TraceContext.Tracestate](https://www.w3.org/TR/trace-context/#tracestate-field) with entries congo=t61rcWkgMzE,rojo=00f067aa0ba902b7
 
 ### Support
 We support a variety of languages and frameworks such as:

--- a/content/introduction/_index.md
+++ b/content/introduction/_index.md
@@ -35,7 +35,8 @@ This log was extracted from a live web application
 ('What is this?', '2019-05-28T18:54:50.767481+00:00'::timestamptz) RETURNING
 "polls_question"."id" /*controller='index',db_driver='django.db.backends.postgresql',
 framework='django%3A2.2.1',route='%5Epolls/%24',
-span_id='cfb60c868a47adf9',trace_id='23d4bad1efad0bff3ebdc7b717d739e7'*/
+traceparent='00-5bd66ef5095369c7b0d1f8f4bd33716a-c532cb4098ac3dd2-01',
+tracestate='congo%%3Dt61rcWkgMzE%%2Crojo%%3D00f067aa0ba902b7'*/
 ```
 
 ### Interpretation
@@ -44,7 +45,8 @@ On examining the SQL statement from above in [Sample](#sample) and examining the
 ```sql
 /*controller='index',db_driver='django.db.backends.postgresql',
 framework='django%3A2.2.1',route='%5Epolls/%24',
-span_id='cfb60c868a47adf9',trace_id='23d4bad1efad0bff3ebdc7b717d739e7'*/
+traceparent='00-5bd66ef5095369c7b0d1f8f4bd33716a-c532cb4098ac3dd2-01',
+tracestate='congo%%3Dt61rcWkgMzE%%2Crojo%%3D00f067aa0ba902b7'*/
 ```
 
 we can now correlate and pinpoint the fields in the above slow SQL query to our source code in our web application:
@@ -55,8 +57,8 @@ Original field|Interpretation
 `db_driver='django.db.backends.postgresql'`|Database driver `django.db.backends.postgresql`
 `framework='django%3A2.2.1'`|Framework version of `django 2.2.1`
 `route='%5Epolls/%24'`|Route of `^/polls/$` 
-`span_id='cfb60c868a47adf9'`|[OpenCensus SpanID](https://opencensus.io/tracing/span/spanid/) of `cfb60c868a47adf9`
-`trace_id='23d4bad1efad0bff3ebdc7b717d739e7'`|[OpenCensus TraceID](https://opencensus.io/tracing/span/traceid/) of `23d4bad1efad0bff3ebdc7b717d739e7`
+`traceparent='00-5bd66ef5095369c7b0d1f8f4bd33716a-c532cb4098ac3dd2-01'`|[W3C TraceContext.Traceparent](https://www.w3.org/TR/trace-context/#traceparent-field) of '00-5bd66ef5095369c7b0d1f8f4bd33716a-c532cb4098ac3dd2-01'
+`tracestate='congo%%3Dt61rcWkgMzE%%2Crojo%%3D00f067aa0ba902b7'`|[W3C TraceContext.Tracestate](https://www.w3.org/TR/trace-context/#tracestate-field) with entries congo=t61rcWkgMzE,rojo=00f067aa0ba902b7
 
 ### Support
 We support a variety of languages and frameworks such as:

--- a/content/python/psycopg2/_index.md
+++ b/content/python/psycopg2/_index.md
@@ -86,8 +86,8 @@ Field|Description
 `dbapi_threadsafety`|The threadsafety API assignment e.g. 2
 `driver_paramstyle`|The Python DB API style of parameters e.g. `pyformat`
 `libpq_version`|The underlying version of [libpq]() that was used by psycopg2
-`span_id`|The SpanID of the OpenCensus trace -- optionally defined with [`with_opencensus=True`](#with-opencensus)
-`trace_id`|The TraceID of the OpenCensus trace -- optionally defined with [`with_opencensus=True`](#with-opencensus)
+`traceparent`|The [W3C TraceContext.Traceparent field](https://www.w3.org/TR/trace-context/#traceparent-field) of the OpenCensus trace -- optionally defined with [`with_opencensus=True`](#with-opencensus)
+`tracestate`|The [W3C TraceContext.Tracestate field](https://www.w3.org/TR/trace-context/#tracestate-field) of the OpenCensus trace -- optionally defined with [`with_opencensus=True`](#with-opencensus)
 
 ### End to end examples
 
@@ -183,7 +183,7 @@ python3 main.py
 
 #### Results
 
-Examining our Postgresql server logs
+Examining our Postgresql server logs, with the various options
 
 {{<tabs "Without OpenCensus" "With OpenCensus">}}
 {{<highlight shell>}}
@@ -193,10 +193,9 @@ dbapi_level='2.0',dbapi_threadsafety=2,driver_paramstyle='pyformat',libpq_versio
 {{</highlight>}}
 
 {{<highlight shell>}}
-2019-06-04 10:38:39.170 PDT [35555] LOG:  statement: SELECT * FROM polls_question
-/*db_driver='psycopg2%%3A2.8.2%%20%%28dt%%20dec%%20pq3%%20ext%%20lo64%%29',
-dbapi_level='2.0',dbapi_threadsafety=2,driver_paramstyle='pyformat',libpq_version=100001,
-span_id='a247e1cdad219d6b',trace_id='de134af00138e4aadc6b386018cace5d'*/
+2019-06-30 17:57:22.758 PDT [96892] LOG:  statement: SELECT * FROM polls_question
+/*traceparent='00-5c2d1bd9cdb4f5fccd7cde6ff4e9b920-e52b708456650bfc-01',
+tracestate='congo%%3Dt61rcWkgMzE%%2Crojo%%3D00f067aa0ba902b7'*/
 {{</highlight>}}
 {{</tabs>}}
 

--- a/content/python/sqlalchemy/_index.md
+++ b/content/python/sqlalchemy/_index.md
@@ -66,9 +66,8 @@ Please ensure that you set `retval=True` when listening for events
 
 and this will produce such output on for example a Postgresql database logs:
 ```shell
-2019-06-04 10:27:14.919 PDT [35412] LOG:  statement: SELECT * FROM polls_question
-/*db_driver='psycopg2',framework='sqlalchemy%3A1.3.4',
-span_id='07ac7d9f6ed8d66e',trace_id='e6e5a8d1a855d7e68aa9b1ab5bf1f027'*/
+2019-06-30 18:01:16.315 PDT [96973] LOG:  statement: SELECT * FROM polls_question
+/*traceparent='00-ade4c36dc5e43b503a5bba237ea11746-578a74a562044332-01'*/
 ```
 
 #### <a name="with-opencensus"></a> with_openCensus=True
@@ -92,8 +91,8 @@ Field|Description
 ---|---
 `db_driver`|The underlying database driver e.g. `'psycopg2'`
 `framework`|The version of SQLAlchemy in the form `'sqlalchemy:<sqlalchemy_version>'`
-`span_id`|The SpanID of the OpenCensus trace -- optionally defined with [`with_opencensus=True`](#with-opencensus)
-`trace_id`|The TraceID of the OpenCensus trace -- optionally defined with [`with_opencensus=True`](#with-opencensus)
+`traceparent`|The [W3C TraceContext.Traceparent field](https://www.w3.org/TR/trace-context/#traceparent-field) of the OpenCensus trace -- optionally defined with [`with_opencensus=True`](#with-opencensus)
+`tracestate`|The [W3C TraceContext.Tracestate field](https://www.w3.org/TR/trace-context/#tracestate-field) of the OpenCensus trace -- optionally defined with [`with_opencensus=True`](#with-opencensus)
 
 ### End to end examples
 


### PR DESCRIPTION
Update the introduction and Python sections to show the output
from W3C TraceContext serialization.

Updates #44