### PR TITLE
node: document how to install from source

### DIFF
--- a/content/node/_index.md
+++ b/content/node/_index.md
@@ -2,11 +2,73 @@
 title: "Node.js"
 date: 2019-05-31T18:16:11-06:00
 draft: false
-weight: 4
+weight: 40
 ---
 
-sqlcommenter support is available for the following [Node.js](https://nodejs.org/) ORMs/frameworks:
+- [Introduction](#introduction)
+- [Integrations](#integrations)
+- [Installation](#install)
+    - [From source](#install-from-source)
+    - [Verify installation](#verify-installation)
+
+### Introduction
+
+sqlcommenter is a suite of plugins/middleware/wrappers to augment SQL statements from ORMs/Querybuilders with comments that can be used later to correlate user code with SQL statements.
+
+### Integrations
+
+sqlcommenter-nodejs provides support for the following:
 
 {{<card-vendor href="/node/knex" src="/images/knex-logo.png">}}
 {{<card-vendor href="/node/sequelize" src="/images/sequelize-logo.png">}}
 {{<card-vendor href="/node/express" src="/images/express_js-logo.png">}}
+
+### <a name="install"></a> Installing it
+sqlcommenter-nodejs can installed in a couple of ways:
+
+#### <a name="install-from-source"></a> From source
+
+The first step is to clone the repository. This can be done with [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) by running:
+{{<highlight shell>}}
+git clone https://github.com/orijtech/sqlcommenter-nodejs.git
+{{</highlight>}}
+Inspect the source code and note the path to the package you want installed.
+
+```shell 
+sqlcommenter-nodejs
+└── packages
+    ├── knex
+    │   ├── index.js
+    │   ├── package.json
+    │   ├── test
+    │   └── ...
+    └── sequelize
+        ├── index.js
+        ├── package.json
+        ├── test
+        └── ...
+```
+Each folder in the `packages` directory can be installed by running 
+
+{{<highlight shell>}}
+npm install <path/to/package>
+{{</highlight>}}
+
+for example to install `@sqlcommenter/knex` in a given location, run `npm install /path/to/sqlcommenter-nodejs/packages/knex`. Same for every package(folder) in the `packages` directory.
+```shell
+# install 
+> npm install /path/to/sqlcommenter-nodejs/packages/knex
+
++ @sqlcommenter/knex@0.0.1
+```
+
+#### <a name="verify-installation"></a> Verify Installation
+If package is properly installed, running `npm list <package-name>` will output details of the package. Let's verify the installation of `@sqlcommenter/knex` below:
+```shell
+# verify
+> npm list @sqlcommenter/knex
+
+project@0.0.0 path/to/project
+└── @sqlcommenter/knex@0.0.1  -> /path/to/sqlcommenter-nodejs/packages/knex
+```
+Inspecting the `package.json` file after installation should also show the installed pacakge.

--- a/content/node/knex/_index.md
+++ b/content/node/knex/_index.md
@@ -11,6 +11,8 @@ tags: ["knex", "knex.js", "query-builder", "node", "node.js", "express", "expres
 - [Introduction](#introduction)
 - [Requirements](#requirements)
 - [Installation](#installation)
+    - [Manually](#manually)
+    - [Package manager](#package-manager)
 - [Usage](#usage)
     - [Plain knex wrapper](#plain-knex-wrapper)
     - [Express middleware](#express-middleware)
@@ -36,18 +38,24 @@ Name|Resource
 Knex.js|https://knexjs.org/
 Node.js|https://nodejs.org/
 
-#### Installation
+### Installation
+
+We can add integration into our applications in the following ways:
+
+#### Manually
+
+Please read [installing sqlcommenter-nodejs from source](/node/#install-from-source)
+
+#### Package manager
 Add to your package.json the dependency
 {{<highlight json>}}
 {
     "@sqlcommenter/knex": "*"
 }
 {{</highlight>}}
-
-or by `npm install` as per:
-
+and then run `npm install` to get the latest version or 
 {{<highlight shell>}}
-npm install @sqlcommenter/knex
+npm install @sqlcommenter/knex --save
 {{</highlight>}}
 
 ### Usage

--- a/content/node/sequelize/_index.md
+++ b/content/node/sequelize/_index.md
@@ -11,6 +11,8 @@ tags: ["sequelize", "sequelize.js", "query-builder", "node", "node.js", "express
 - [Introduction](#introduction)
 - [Requirements](#requirements)
 - [Installation](#installation)
+    - [Manually](#manually)
+    - [Package manager](#package-manager)
 - [Usage](#usage)
     - [Plain sequelize wrapper](#plain-sequelize-wrapper)
     - [Express middleware](#express-middleware)
@@ -34,7 +36,15 @@ Besides plain sequelize.js wrapping, we also provide a wrapper for the following
 * [Sequelize.js](http://docs.sequelizejs.com/)
 * [Node.js](https://nodejs.org/)
 
-#### Installation
+### Installation
+
+We can add integration into our applications in the following ways:
+
+#### Manually
+
+Please read [installing sqlcommenter-nodejs from source](/node/#install-from-source)
+
+#### Package manager
 Add to your package.json the dependency
 {{<highlight json>}}
 {
@@ -42,10 +52,10 @@ Add to your package.json the dependency
 }
 {{</highlight>}}
 
-or by `npm install` as per:
+and then run `npm install` to get the latest version or
 
 {{<highlight shell>}}
-npm install @sqlcommenter/sequelize
+npm install @sqlcommenter/sequelize --save
 {{</highlight>}}
 
 ### Usage


### PR DESCRIPTION
Adds explicit instructions on how to install packages from
source as well as expectations.

Fixes #38