### PR TITLE
Flush out SLQAlchemy examples

### DIFF
--- a/content/python/sqlalchemy/_index.md
+++ b/content/python/sqlalchemy/_index.md
@@ -90,7 +90,7 @@ Please ensure that you set `retval=True` when listening for events
 Field|Description
 ---|---
 `db_driver`|The underlying database driver e.g. `'psycopg2'`
-`framework`|The version of SQLAlchemy in the form `'sqlalchemy:<sqlalchemy_version>'`
+`db_framework`|The version of SQLAlchemy in the form `'sqlalchemy:<sqlalchemy_version>'`
 `traceparent`|The [W3C TraceContext.Traceparent field](https://www.w3.org/TR/trace-context/#traceparent-field) of the OpenCensus trace -- optionally defined with [`with_opencensus=True`](#with-opencensus)
 `tracestate`|The [W3C TraceContext.Tracestate field](https://www.w3.org/TR/trace-context/#tracestate-field) of the OpenCensus trace -- optionally defined with [`with_opencensus=True`](#with-opencensus)
 


### PR DESCRIPTION
Resolves #55 

This PR also fixes an issue with the `db_framework` field. We changed the name of this field from `framework` to `db_framework` a few weeks ago. `framework` now refers to the web framework, if present. That's covered in 4916797.

I've ran all the examples in my local dev environment to make sure there's no typos in them.

Let me know if you'd like to see any adjustments. Cheers.