### PR TITLE
node: update sequelize and knex docs for TraceProvider

### DIFF
--- a/content/node/knex/_index.md
+++ b/content/node/knex/_index.md
@@ -95,7 +95,6 @@ In the database server logs, the comment's fields are:
 
 | Field             | Format                        | Description                                                                                          | Example                                                                 |
 |-------------------|-------------------------------|------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
-| `client_timezone` | `<string>`                    | URL quoted name of the timezone used when converting a date from the database into a JavaScript date | `'+00:00'`                                                              |
 | `db_driver`       | `<database_driver>:<version>` | URL quoted name and version of the database driver                                                   | `db_driver='knex%3A0.16.5'`                                             |
 | `route`           | `<the route used>`            | URL quoted route used to match the express.js controller                                             | `route='%5E%2Fpolls%2F`                                                 |
 | `traceparent`     | `<traceparent header>`        | URL quoted [W3C `traceparent` header](https://www.w3.org/TR/trace-context/#traceparent-header)       | `traceparent='00-3e2914ebce6af09508dd1ff1128493a8-81d09ab4d8cde7cf-01'` |
@@ -211,9 +210,9 @@ const knex = Knex(knexOptions); // knex instance
 const app = express();
 const port = process.env.APP_PORT || 3000;
 
-// Use the knex+express middleware with trace attributes 
+// Use the knex+express middleware with trace attributes
 app.use(wrapMainKnexAsMiddleware(Knex, {
-    traceparent: true, 
+    traceparent: true,
     tracestate: true,
     route: false
 }));
@@ -273,11 +272,12 @@ app.use(
   wrapMainKnexAsMiddleware(
     Knex,
     {
-      client_timezone: true,
-      db_driver: true,
-      route: true,
       traceparent: true,
       tracestate: true,
+
+      // Optional
+      db_driver: false,
+      route: false,
     },
     { TraceProvider: "OpenTelemetry" }
   )

--- a/content/node/knex/_index.md
+++ b/content/node/knex/_index.md
@@ -112,12 +112,12 @@ wrapMainKnexAsMiddleware(Knex, include={...}, options={...});
 ##### `include`
 A map of values to be optionally included in the SQL comments.
 
-| Field           | On by default |
-| --------------- | ------------- |
-| db_driver       | No            |
-| route           | Yes           |
-| traceparent     | No            |
-| tracestate      | No            |
+| Field       | On by default |
+|-------------|---------------|
+| db_driver   | {{<uncheck>}} |
+| route       | {{<check>}}   |
+| traceparent | {{<uncheck>}} |
+| tracestate  | {{<uncheck>}} |
 
 ##### `options`
 A configuration object specifying where to collect trace data from. Accepted

--- a/content/node/knex/_index.md
+++ b/content/node/knex/_index.md
@@ -18,6 +18,8 @@ tags: ["knex", "knex.js", "query-builder", "node", "node.js", "express", "expres
     - [Express middleware](#express-middleware)
 - [Fields](#fields)
     - [Options](#options)
+        - [`include` config](#include-config)
+        - [`options` config](#options-config)
         - [Options examples](#options-examples)
 - [End to end examples](#end-to-examples)
     - [Source code](#source-code)
@@ -109,7 +111,7 @@ comments by passing in the `include` and `options` objects:
 wrapMainKnexAsMiddleware(Knex, include={...}, options={...});
 ```
 
-##### `include`
+##### `include` config
 A map of values to be optionally included in the SQL comments.
 
 | Field       | On by default |
@@ -119,7 +121,7 @@ A map of values to be optionally included in the SQL comments.
 | traceparent | {{<uncheck>}} |
 | tracestate  | {{<uncheck>}} |
 
-##### `options`
+##### `options` config
 A configuration object specifying where to collect trace data from. Accepted
 fields are: TraceProvider: Should be either `OpenCensus` or `OpenTelemetry`,
 indicating which library to collect trace context from.

--- a/content/node/sequelize/_index.md
+++ b/content/node/sequelize/_index.md
@@ -386,9 +386,11 @@ app.use(wrapSequelizeAsMiddleware(
     {
         traceparent: true,
         tracestate: true,
-        route: true,
-        db_driver: true,
-        client_timezone: true
+
+        // Optional
+        route: false,
+        db_driver: false,
+        client_timezone: false
     },
     {
         TraceProvider: "OpenCensus",

--- a/content/node/sequelize/_index.md
+++ b/content/node/sequelize/_index.md
@@ -112,12 +112,12 @@ wrapMainSequelizeAsMiddleware(Sequelize, include={...}, options={...});
 A map of values to be optionally included in the SQL comments.
 
 | Field           | On by default |
-| --------------- | ------------- |
-| client_timezone | No            |
-| db_driver       | No            |
-| route           | Yes           |
-| traceparent     | No            |
-| tracestate      | No            |
+|-----------------|---------------|
+| client_timezone | {{<uncheck>}} |
+| db_driver       | {{<uncheck>}} |
+| route           | {{<check>}}   |
+| traceparent     | {{<uncheck>}} |
+| tracestate      | {{<uncheck>}} |
 
 ##### `options`
 A configuration object specifying where to collect trace data from. Accepted

--- a/content/node/sequelize/_index.md
+++ b/content/node/sequelize/_index.md
@@ -17,6 +17,8 @@ tags: ["sequelize", "sequelize.js", "query-builder", "node", "node.js", "express
   - [Express middleware](#express-middleware)
 - [Fields](#fields)
   - [Options](#options)
+    - [`include` config](#include-config)
+    - [`options` config](#options-config)
     - [Options examples](#options-examples)
 - [End to end examples](#end-to-end-examples)
   - [Source code](#source-code)
@@ -108,7 +110,7 @@ comments by passing in the `include` and `options` objects:
 wrapMainSequelizeAsMiddleware(Sequelize, include={...}, options={...});
 ```
 
-##### `include`
+##### `include` config
 A map of values to be optionally included in the SQL comments.
 
 | Field           | On by default |
@@ -119,7 +121,7 @@ A map of values to be optionally included in the SQL comments.
 | traceparent     | {{<uncheck>}} |
 | tracestate      | {{<uncheck>}} |
 
-##### `options`
+##### `options` config
 A configuration object specifying where to collect trace data from. Accepted
 fields are: TraceProvider: Should be either `OpenCensus` or `OpenTelemetry`,
 indicating which library to collect trace context from.

--- a/layouts/shortcodes/check.html
+++ b/layouts/shortcodes/check.html
@@ -1,0 +1,1 @@
+<div style="text-align: center">&#10004;</div>

--- a/layouts/shortcodes/uncheck.html
+++ b/layouts/shortcodes/uncheck.html
@@ -1,0 +1,1 @@
+<div style="text-align: center">&#10060;</div>


### PR DESCRIPTION
These have a bit more than #70 #69 which can be closed after this PR.

- update sequelize documentation with TraceProvider and samples
- update knex documentation with TraceProvider and samples
